### PR TITLE
modal fix: ensure title is mandatory, add hiddenTitle property

### DIFF
--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -33,9 +33,10 @@ export const ModalWithTitle: Story = {
 export const ModalWithControl: Story = {
   args: {
     children: "",
+    title: "Control",
     trigger: ""
   },
-  render: () => {
+  render: args => {
     const [isOpen, setIsOpen] = useState(false)
 
     const closeModal = () => {
@@ -46,12 +47,51 @@ export const ModalWithControl: Story = {
       <Modal
         onOpenChange={setIsOpen}
         open={isOpen}
+        title={args.title}
         trigger={<Button variant={"outlined"}>Click me</Button>}
       >
         <img
           alt={""}
           src={
-            "https://vjoy.cc/wp-content/uploads/2020/06/98359-gorizont-palma-plyazh-more-komnata-1080x1920-1.jpg"
+            "https://images.pexels.com/photos/17603742/pexels-photo-17603742/free-photo-of-college-student-chatgpt-for-studying.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+          }
+          style={{ filter: "brightness(0.8)" }}
+          width={360}
+        />
+        <Button fullWidth onClick={closeModal} variant={"primary"}>
+          Send
+        </Button>
+      </Modal>
+    )
+  }
+}
+
+export const ModalWithHiddenTitle: Story = {
+  args: {
+    children: "",
+    hiddenTitle: true,
+    title: "Hidden Title",
+    trigger: ""
+  },
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const closeModal = () => {
+      setIsOpen(false)
+    }
+
+    return (
+      <Modal
+        hiddenTitle={args.hiddenTitle}
+        onOpenChange={setIsOpen}
+        open={isOpen}
+        title={args.title}
+        trigger={<Button variant={"outlined"}>Click me</Button>}
+      >
+        <img
+          alt={""}
+          src={
+            "https://images.pexels.com/photos/17603742/pexels-photo-17603742/free-photo-of-college-student-chatgpt-for-studying.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
           }
           style={{ filter: "brightness(0.8)" }}
           width={360}

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,19 +1,22 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react"
 
 import * as Dialog from "@radix-ui/react-dialog"
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
 
 import s from "./modal.module.scss"
 
 import { IconClose } from "../../assets/icons/components"
 import { Typography } from "../typography"
+
 type Props = {
   children: ReactNode
   className?: string
-  title?: string
+  hiddenTitle?: boolean
+  title: string
   trigger?: ReactNode
 } & ComponentPropsWithoutRef<typeof Dialog.Root>
 export const Modal = (props: Props) => {
-  const { children, className, title, trigger, ...restProps } = props
+  const { children, className, hiddenTitle, title, trigger, ...restProps } = props
 
   return (
     <Dialog.Root {...restProps}>
@@ -21,20 +24,20 @@ export const Modal = (props: Props) => {
       <Dialog.Portal>
         <Dialog.Overlay className={s.dialogOverlay} />
         <Dialog.Content className={s.dialogContent}>
-          {title && (
-            <>
-              <Dialog.Title asChild>
-                <div className={s.dialogHeader}>
-                  <Typography variant={"h1"}>{title}</Typography>
-                  {
-                    <Dialog.Close className={s.closeButton}>
-                      <IconClose />
-                    </Dialog.Close>
-                  }
-                </div>
-              </Dialog.Title>
-            </>
-          )}
+          <Dialog.Title asChild>
+            {hiddenTitle ? (
+              <VisuallyHidden>
+                <Typography variant={"h1"}>{title}</Typography>
+              </VisuallyHidden>
+            ) : (
+              <div className={s.dialogHeader}>
+                <Typography variant={"h1"}>{title}</Typography>
+                <Dialog.Close className={s.closeButton}>
+                  <IconClose />
+                </Dialog.Close>
+              </div>
+            )}
+          </Dialog.Title>
           <Dialog.Description asChild>
             <div className={className}>{children}</div>
           </Dialog.Description>


### PR DESCRIPTION
- Made the title a required property for the modal
- Introduce the hiddenTitle property to prevent console errors when the title is not meant to be displayed
- Add a story to the Storybook

In my opinion It is the only possible way to prevent console errors. So guys, we must update all existing Modals to include the “title” property. If the title is not meant to be displayed, we should also add the “hiddenTitle” property.